### PR TITLE
Add ncurses library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ used libraries and build tools.
 
 Here are the latest images currently published in Docker Hub:
 
-* `utdemir/ghc-musl:v4-libgmp-ghc881`
-* `utdemir/ghc-musl:v4-integer-simple-ghc881`
-* `utdemir/ghc-musl:v4-libgmp-ghc865`
-* `utdemir/ghc-musl:v4-integer-simple-ghc865`
-* `utdemir/ghc-musl:v4-libgmp-ghc844`
+* `utdemir/ghc-musl:v5-libgmp-ghc881`
+* `utdemir/ghc-musl:v5-integer-simple-ghc881`
+* `utdemir/ghc-musl:v5-libgmp-ghc865`
+* `utdemir/ghc-musl:v5-integer-simple-ghc865`
+* `utdemir/ghc-musl:v5-libgmp-ghc844`
 
 ## Usage
 
@@ -27,7 +27,7 @@ inside the container:
 
 ```
 $ cd myproject/
-$ docker run -itv $(pwd):/mnt utdemir/ghc-musl:v4-libgmp-ghc881
+$ docker run -itv $(pwd):/mnt utdemir/ghc-musl:v5-libgmp-ghc881
 sh$ cd /mnt
 sh$ cabal new-update
 sh$ cabal new-build
@@ -41,7 +41,7 @@ host machine:
 ```
 docker:
   enable: true
-  image: utdemir/ghc-musl:v4-libgmp-ghc881
+  image: utdemir/ghc-musl:v5-libgmp-ghc881
 ```
 
 Make sure to pick an image with the GHC version compatible with the

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
 user = "utdemir";
 name = "ghc-musl";
 tag = lib.concatStringsSep "-" [
-  "v4"
+  "v5"
   (if integer-simple then "integer-simple" else "libgmp")
   compiler
 ];

--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@ libraries = with pkgsMusl; [
   musl
   zlib zlib.static
   libffi (libffi.override { stdenv = makeStaticLibraries stdenv; })
+  ncurses (ncurses.override { enableStatic = true; })
 ] ++ lib.optionals (!integer-simple) [ gmp (gmp.override { withStatic = true; }) ];
 
 packages = with pkgsMusl; [


### PR DESCRIPTION
Closes #4.

This adds ncurses library to the containers which should
include the `tinfo` object.

I'll try building `summoner-tui` to test once the build finishes.