### PR TITLE
link ncursesw to tinfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ RUN ghcup install cabal "$CABAL_VERSION" \
 
 ENV PATH="/usr/local/.ghcup/bin:$PATH"
 
+RUN ln -s /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.6
+
 RUN cabal new-update


### PR DESCRIPTION
This is needed since otherwise when you install `stack` inside the container, it complaints about missing setup information. Ex:

```
No setup information found for ghc-8.8.4 on your platform.
```