### PR TITLE
Update ghc

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -89,8 +89,8 @@ image:
 ghc944:
   BUILD +image --GHC=9.4.4 --TAG=${BASE_TAG}ghc944
 
-ghc926:
-  BUILD +image --GHC=9.2.6 --TAG=${BASE_TAG}ghc926
+ghc927:
+  BUILD +image --GHC=9.2.7 --TAG=${BASE_TAG}ghc927
 
 ghc902:
   BUILD +image --GHC=9.0.2 --TAG=${BASE_TAG}ghc902
@@ -106,7 +106,7 @@ readme:
   COPY ./update-readme.sh .
   RUN ./update-readme.sh \
         "${BASE_TAG}ghc944" \
-        "${BASE_TAG}ghc926" \
+        "${BASE_TAG}ghc927" \
         "${BASE_TAG}ghc902" \
         "${BASE_TAG}ghc8107" \
         "${BASE_TAG}ghc884"
@@ -114,7 +114,7 @@ readme:
 
 all:
   BUILD +ghc944
-  BUILD +ghc926
+  BUILD +ghc927
   BUILD +ghc902
   BUILD +ghc8107
   BUILD +ghc884

--- a/Earthfile
+++ b/Earthfile
@@ -86,6 +86,9 @@ image:
   END
   SAVE IMAGE --push "$TAG"
 
+ghc961:
+  BUILD +image --GHC=9.6.1 --TAG=${BASE_TAG}ghc961
+
 ghc944:
   BUILD +image --GHC=9.4.4 --TAG=${BASE_TAG}ghc944
 
@@ -105,6 +108,7 @@ readme:
   RUN apk add bash gettext
   COPY ./update-readme.sh .
   RUN ./update-readme.sh \
+        "${BASE_TAG}ghc961" \
         "${BASE_TAG}ghc944" \
         "${BASE_TAG}ghc927" \
         "${BASE_TAG}ghc902" \
@@ -113,6 +117,7 @@ readme:
   SAVE ARTIFACT README.md
 
 all:
+  BUILD +ghc961
   BUILD +ghc944
   BUILD +ghc927
   BUILD +ghc902


### PR DESCRIPTION
* GHC 9.2.6 → 9.2.7
* GHC 9.6.1

Images build without issue.  (Tests pass.)  Note that `ghci` is still broken in the official Alpine builds.