### PR TITLE
Add GHC 9.6.4

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -86,8 +86,8 @@ image:
   END
   SAVE IMAGE --push "$TAG"
 
-ghc961:
-  BUILD +image --GHC=9.6.1 --TAG=${BASE_TAG}ghc961
+ghc964:
+  BUILD +image --GHC=9.6.4 --TAG=${BASE_TAG}ghc964
 
 ghc944:
   BUILD +image --GHC=9.4.4 --TAG=${BASE_TAG}ghc944
@@ -108,7 +108,7 @@ readme:
   RUN apk add bash gettext
   COPY ./update-readme.sh .
   RUN ./update-readme.sh \
-        "${BASE_TAG}ghc961" \
+        "${BASE_TAG}ghc964" \
         "${BASE_TAG}ghc944" \
         "${BASE_TAG}ghc927" \
         "${BASE_TAG}ghc902" \
@@ -117,7 +117,7 @@ readme:
   SAVE ARTIFACT README.md
 
 all:
-  BUILD +ghc961
+  BUILD +ghc964  
   BUILD +ghc944
   BUILD +ghc927
   BUILD +ghc902


### PR DESCRIPTION
It looks like a fix for this one
https://github.com/utdemir/ghc-musl/issues/29
is added to GHC 9.6.4 (and perhaps, 9.6.3 as well, but I didn't test).

I tested it and indeed projects with `wai-app-static` dependencies build without problems.
